### PR TITLE
Fix Sixel scaling and add Sixel-only rendering mode

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -9,6 +9,7 @@ pub struct CommandLine {
     pub zoom: f32,
     pub debug: bool,
     pub bitmap: bool,
+    pub sixel_only: bool,
     pub program: CommandLineProgram,
     pub shell_mode: bool,
 }
@@ -16,6 +17,7 @@ pub struct CommandLine {
 pub enum EnvVar {
     Debug,
     Bitmap,
+    SixelOnly,
     ShellMode,
 }
 
@@ -24,6 +26,7 @@ impl EnvVar {
         match self {
             EnvVar::Debug => "CARBONYL_ENV_DEBUG",
             EnvVar::Bitmap => "CARBONYL_ENV_BITMAP",
+            EnvVar::SixelOnly => "CARBONYL_ENV_SIXEL_ONLY",
             EnvVar::ShellMode => "CARBONYL_ENV_SHELL_MODE",
         }
     }
@@ -41,6 +44,7 @@ impl CommandLine {
         let mut zoom = 1.0;
         let mut debug = false;
         let mut bitmap = false;
+        let mut sixel_only = false;
         let mut shell_mode = false;
         let mut program = CommandLineProgram::Main;
         let args = env::args().skip(1).collect::<Vec<String>>();
@@ -77,6 +81,7 @@ impl CommandLine {
                 "-z" | "--zoom" => set_f32!(zoom = zoom / 100.0),
                 "-d" | "--debug" => set!(debug, Debug),
                 "-b" | "--bitmap" => set!(bitmap, Bitmap),
+                "--sixel-only" => set!(sixel_only, SixelOnly),
 
                 "-h" | "--help" => program = CommandLineProgram::Help,
                 "-v" | "--version" => program = CommandLineProgram::Version,
@@ -92,6 +97,10 @@ impl CommandLine {
             bitmap = true;
         }
 
+        if env::var(EnvVar::SixelOnly).is_ok() {
+            sixel_only = true;
+        }
+
         if env::var(EnvVar::ShellMode).is_ok() {
             shell_mode = true;
         }
@@ -102,6 +111,7 @@ impl CommandLine {
             zoom,
             debug,
             bitmap,
+            sixel_only,
             program,
             shell_mode,
         }

--- a/src/output/render_thread.rs
+++ b/src/output/render_thread.rs
@@ -59,7 +59,7 @@ impl RenderThread {
     fn boot(rx: Receiver<Message>) {
         let cmd = CommandLine::parse();
         let mut sync = FrameSync::new(cmd.fps);
-        let mut renderer = Renderer::new();
+        let mut renderer = Renderer::new(cmd.sixel_only);
         let mut needs_render = false;
 
         loop {

--- a/src/output/renderer.rs
+++ b/src/output/renderer.rs
@@ -23,11 +23,14 @@ pub struct Renderer {
 }
 
 impl Renderer {
-    pub fn new() -> Renderer {
+    pub fn new(sixel_only: bool) -> Renderer {
+        let mut painter = Painter::new();
+        painter.set_sixel_only(sixel_only);
+
         Renderer {
             nav: Navigation::new(),
             cells: Vec::with_capacity(0),
-            painter: Painter::new(),
+            painter,
             size: Size::new(0, 0),
         }
     }
@@ -38,6 +41,10 @@ impl Renderer {
 
     pub fn enable_sixel(&mut self, geometry: Size) {
         self.painter.enable_sixel(geometry);
+    }
+
+    pub fn update_sixel_geometry(&mut self, geometry: Size) {
+        self.painter.update_sixel_geometry(geometry);
     }
 
     pub fn keypress(&mut self, key: &Key) -> io::Result<NavigationAction> {

--- a/src/output/window.rs
+++ b/src/output/window.rs
@@ -1,5 +1,11 @@
 use core::mem::MaybeUninit;
-use std::str::FromStr;
+use std::{
+    fs::OpenOptions,
+    io::{Read, Write},
+    os::fd::AsRawFd,
+    str::FromStr,
+    time::{Duration, Instant},
+};
 
 use crate::{cli::CommandLine, gfx::Size, utils::log};
 
@@ -50,11 +56,6 @@ impl Window {
             }
         };
 
-        if cell.width == 0 || cell.height == 0 {
-            cell.width = 8;
-            cell.height = 16;
-        }
-
         if term.width == 0 || term.height == 0 {
             let cols = match parse_var("COLUMNS").unwrap_or(0) {
                 0 => 80,
@@ -77,19 +78,27 @@ impl Window {
             term.height = rows;
         }
 
-        let zoom = 1.5 * self.cmd.zoom;
+        let zoom = self.cmd.zoom.max(0.01);
         let cells = Size::new(term.width.max(1), term.height.max(2) - 1);
-        let auto_scale = false;
-        let cell_pixels = if auto_scale {
-            Size::new(cell.width as f32, cell.height as f32) / cells.cast()
-        } else {
-            Size::new(8.0, 16.0)
-        };
+        let mut cell_pixels =
+            if term.width > 0 && term.height > 0 && cell.width > 0 && cell.height > 0 {
+                Size::new(
+                    cell.width as f32 / term.width.max(1) as f32,
+                    cell.height as f32 / term.height.max(1) as f32,
+                )
+            } else {
+                Size::new(0.0, 0.0)
+            };
+
+        if cell_pixels.width <= 0.0 || cell_pixels.height <= 0.0 {
+            cell_pixels = query_cell_geometry().unwrap_or(Size::new(8.0, 16.0));
+        }
         // Normalize the cells dimensions for an aspect ratio of 1:2
         let cell_width = (cell_pixels.width + cell_pixels.height / 2.0) / 2.0;
 
-        // Round DPI to 2 decimals for proper viewport computations
-        self.dpi = (2.0 / cell_width * zoom * 100.0).ceil() / 100.0;
+        let dpi = 2.0 / cell_width * zoom;
+        // Round DPI to 4 decimals for stable viewport computations
+        self.dpi = (dpi * 10000.0).round() / 10000.0;
         // A virtual cell should contain a 2x4 pixel quadrant
         self.scale = Size::new(2.0, 4.0) / self.dpi;
         // Keep some space for the UI
@@ -102,4 +111,100 @@ impl Window {
 
 fn parse_var<T: FromStr>(var: &str) -> Option<T> {
     std::env::var(var).ok()?.parse().ok()
+}
+
+fn query_cell_geometry() -> Option<Size<f32>> {
+    let mut tty = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+        .ok()?;
+    let fd = tty.as_raw_fd();
+    let mut term = MaybeUninit::<libc::termios>::uninit();
+
+    unsafe {
+        if libc::tcgetattr(fd, term.as_mut_ptr()) != 0 {
+            return None;
+        }
+    }
+
+    let original = unsafe { term.assume_init() };
+    let mut raw = original;
+    let c_oflag = raw.c_oflag;
+
+    unsafe {
+        libc::cfmakeraw(&mut raw);
+    }
+
+    raw.c_oflag = c_oflag;
+
+    if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw) } != 0 {
+        return None;
+    }
+
+    struct Restore(libc::c_int, libc::termios);
+
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            unsafe {
+                libc::tcsetattr(self.0, libc::TCSANOW, &self.1);
+            }
+        }
+    }
+
+    let _restore = Restore(fd, original);
+
+    if tty.write_all(b"\x1b[16t").is_err() || tty.flush().is_err() {
+        return None;
+    }
+
+    let mut buffer = [0u8; 128];
+    let mut length = 0usize;
+    let deadline = Instant::now() + Duration::from_millis(100);
+
+    while length < buffer.len() && Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let timeout = remaining.as_millis().min(i32::MAX as u128) as libc::c_int;
+        let mut fds = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+
+        let result = unsafe { libc::poll(&mut fds, 1, timeout) };
+
+        if result <= 0 {
+            break;
+        }
+
+        match tty.read(&mut buffer[length..]) {
+            Ok(0) => break,
+            Ok(read) => {
+                length += read;
+
+                if buffer[..length].contains(&b't') {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    if length == 0 {
+        return None;
+    }
+
+    let response = std::str::from_utf8(&buffer[..length]).ok()?;
+    let start = response.rfind("\u{1b}[6;")?;
+    let rest = &response[start + 3..];
+    let end = rest.find('t')?;
+    let mut parts = rest[..end].split(';');
+    let height = parts.next()?.parse::<f32>().ok()?;
+    let width = parts.next()?.parse::<f32>().ok()?;
+
+    if width <= 0.0 || height <= 0.0 {
+        return None;
+    }
+
+    Some(Size::new(width, height))
 }


### PR DESCRIPTION
## Summary
- detect the terminal cell size via CSI 16 t so the window DPI, scale, and browser pixel size match the real terminal geometry
- propagate the measured geometry to the Sixel renderer, update it on resize, and clear the screen when drawing Sixel-only frames
- add a `--sixel-only` CLI switch that disables the legacy text renderer when Sixel output is active

## Testing
- `cargo fmt`
- `cargo check` *(fails: Chromium sysroot missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daf0afb668832eb3257f42d26d62ad