### PR TITLE
Respect the legacy renderer opt-out when enabling Sixel output

### DIFF
--- a/src/cli/usage.txt
+++ b/src/cli/usage.txt
@@ -10,6 +10,7 @@ Options:
     -f, --fps=<fps>            set the maximum number of frames per second (default: 60)
     -z, --zoom=<zoom>          set the zoom level in percent (default: 100)
     -b, --bitmap               render text as bitmaps
+    --legacy-text              disable Sixel output and use the legacy text renderer
     -d, --debug                enable debug logs
     -h, --help                 display this help message
     -v, --version              output the version number

--- a/src/output/render_thread.rs
+++ b/src/output/render_thread.rs
@@ -59,7 +59,7 @@ impl RenderThread {
     fn boot(rx: Receiver<Message>) {
         let cmd = CommandLine::parse();
         let mut sync = FrameSync::new(cmd.fps);
-        let mut renderer = Renderer::new();
+        let mut renderer = Renderer::new(cmd.sixel_only);
         let mut needs_render = false;
 
         loop {

--- a/src/output/renderer.rs
+++ b/src/output/renderer.rs
@@ -23,11 +23,14 @@ pub struct Renderer {
 }
 
 impl Renderer {
-    pub fn new() -> Renderer {
+    pub fn new(sixel_only: bool) -> Renderer {
+        let mut painter = Painter::new();
+        painter.set_sixel_only(sixel_only);
+
         Renderer {
             nav: Navigation::new(),
             cells: Vec::with_capacity(0),
-            painter: Painter::new(),
+            painter,
             size: Size::new(0, 0),
         }
     }
@@ -38,6 +41,10 @@ impl Renderer {
 
     pub fn enable_sixel(&mut self, geometry: Size) {
         self.painter.enable_sixel(geometry);
+    }
+
+    pub fn update_sixel_geometry(&mut self, geometry: Size) {
+        self.painter.update_sixel_geometry(geometry);
     }
 
     pub fn keypress(&mut self, key: &Key) -> io::Result<NavigationAction> {


### PR DESCRIPTION
## Summary
- skip Sixel geometry updates during resize unless the session is running in Sixel mode
- only enable the Sixel presenter when the command line has not requested the legacy text renderer
- clarify in the CLI usage text that `--legacy-text` disables Sixel output entirely

## Testing
- `cargo fmt`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68daf0afb668832eb3257f42d26d62ad