### PR TITLE
Default to Sixel rendering and add legacy opt-in

### DIFF
--- a/src/cli/usage.txt
+++ b/src/cli/usage.txt
@@ -9,6 +9,7 @@ Usage: carbonyl [options] [url]
 Options:
     -f, --fps=<fps>            set the maximum number of frames per second (default: 60)
     -z, --zoom=<zoom>          set the zoom level in percent (default: 100)
+        --legacy-text          re-enable the legacy ANSI text renderer
     -b, --bitmap               render text as bitmaps
     -d, --debug                enable debug logs
     -h, --help                 display this help message


### PR DESCRIPTION
## Summary
- default the CLI to Sixel-only rendering and propagate the preference through the environment
- add a --legacy-text flag and update usage docs to describe opting into the ANSI renderer

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68daf987e7bc832e937aa58ca439896b