### PR TITLE
Fix terminal window update warnings

### DIFF
--- a/src/output/window.rs
+++ b/src/output/window.rs
@@ -41,7 +41,7 @@ impl Window {
     }
 
     pub fn update(&mut self) -> &Self {
-        let (mut term, mut cell) = unsafe {
+        let (mut term, cell) = unsafe {
             let mut ptr = MaybeUninit::<libc::winsize>::uninit();
 
             if libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, ptr.as_mut_ptr()) == 0 {
@@ -79,7 +79,6 @@ impl Window {
         }
 
         let zoom = self.cmd.zoom.max(0.01);
-        let cells = Size::new(term.width.max(1), term.height.max(2) - 1);
         let mut cell_pixels =
             if term.width > 0 && term.height > 0 && cell.width > 0 && cell.height > 0 {
                 Size::new(


### PR DESCRIPTION
## Summary
- stop creating an unused `cells` value when updating the window
- avoid marking the retrieved cell size as mutable when it is not changed

## Testing
- cargo check *(fails: build of sixel-sys-static stalled in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dafad1c778832eabe254a466f19939