### PR TITLE
Fix SIXEL rendering resolution and palette handling

### DIFF
--- a/src/output/painter.rs
+++ b/src/output/painter.rs
@@ -76,7 +76,7 @@ impl Painter {
                         _ => None,
                     }
                 })
-                .unwrap_or(true);
+                .unwrap_or(false);
 
             SixelState {
                 configured: false,
@@ -157,9 +157,7 @@ impl Painter {
             }
 
             if let Some(frame) = state.pending.take() {
-                if self.sixel_only {
-                    write!(self.buffer, "\x1b[H\x1b[2J")?;
-                }
+                // Reposition cursor without clearing the entire screen.
                 write!(self.buffer, "\x1b[H")?;
                 self.buffer.extend_from_slice(&frame.bytes);
                 write!(self.buffer, "\x1b[H")?;

--- a/src/output/sixel.rs
+++ b/src/output/sixel.rs
@@ -28,8 +28,8 @@ impl Frame {
             pixels,
             size.width as i32,
             size.height as i32,
-            sixel_bytes::PixelFormat::RGBA8888,
-            sixel_bytes::DiffusionMethod::Auto,
+            sixel_bytes::PixelFormat::BGRA8888,
+            sixel_bytes::DiffusionMethod::Ordered,
         )
         .map_err(Error::from)?
         .into_bytes();

--- a/src/output/window.rs
+++ b/src/output/window.rs
@@ -114,11 +114,12 @@ impl Window {
         self.scale = Size::new(2.0, 4.0) / self.dpi;
         // Keep some space for the UI
         self.cells = Size::new(term.width.max(1), term.height.max(2) - 1).cast();
-        self.browser = self.cells.cast::<f32>().mul(self.scale).ceil().cast();
         self.graphics_px = Size::new(
             (self.cells.width as f32 * cell_pixels.width).round() as u32,
             (self.cells.height as f32 * cell_pixels.height).round() as u32,
         );
+        // Request Chromium to render at the full terminal pixel size so no scaling is needed
+        self.browser = self.graphics_px;
 
         self
     }


### PR DESCRIPTION
## Summary
- request Chromium to render at the terminal's pixel resolution to avoid scaling artifacts
- encode SIXEL frames as BGRA with ordered diffusion for stable colors
- stop per-frame screen clears and default SIXEL scrolling to off to reduce flicker

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db07a8b9d0832e8c150dc3473b8e9b