### PR TITLE
Fix sixel diffusion method for new crate version

### DIFF
--- a/src/output/sixel.rs
+++ b/src/output/sixel.rs
@@ -29,7 +29,7 @@ impl Frame {
             size.width as i32,
             size.height as i32,
             sixel_bytes::PixelFormat::BGRA8888,
-            sixel_bytes::DiffusionMethod::Ordered,
+            sixel_bytes::DiffusionMethod::Auto,
         )
         .map_err(Error::from)?
         .into_bytes();


### PR DESCRIPTION
## Summary
- update the sixel encoder to use the available `Auto` diffusion method

## Testing
- cargo build *(fails: linking with `cc` because libsixel static library is not built with -fPIC in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db086a9764832e82c6271ce12b884d