### PR TITLE
Wire DSF and zoom through bridge

### DIFF
--- a/chromium/patches/chromium/0013-Refactor-rendering-bridge.patch
+++ b/chromium/patches/chromium/0013-Refactor-rendering-bridge.patch
@@ -90,10 +90,12 @@ index 0000000000000..a61668050cf0e
 +#include "build/build_config.h"
 +#include "components/viz/common/resources/resource_sizes.h"
 +#include "components/viz/service/display_embedder/output_device_backing.h"
++#include "carbonyl/src/browser/bridge.h"
 +#include "mojo/public/cpp/system/platform_handle.h"
 +#include "services/viz/privileged/mojom/compositing/layered_window_updater.mojom.h"
 +#include "skia/ext/platform_canvas.h"
 +#include "third_party/skia/include/core/SkCanvas.h"
++#include "ui/gfx/geometry/size_conversions.h"
 +#include "ui/gfx/skia_util.h"
 +
 +#if BUILDFLAG(IS_WIN)
@@ -116,10 +118,13 @@ index 0000000000000..a61668050cf0e
 +  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
 +  DCHECK(!in_paint_);
 +
-+  if (viewport_pixel_size_ == viewport_pixel_size)
++  auto dsf = carbonyl::Bridge::GetDeviceScaleFactor();
++  gfx::Size physical_size = gfx::ScaleToCeiledSize(viewport_pixel_size, dsf);
++
++  if (viewport_pixel_size_ == physical_size)
 +    return;
 +
-+  viewport_pixel_size_ = viewport_pixel_size;
++  viewport_pixel_size_ = physical_size;
 +  ResizeDelegated();
 +}
 +
@@ -774,6 +779,7 @@ index a166a08f6ea15..091bde787d47c 100644
  #include "build/build_config.h"
  #include "build/chromeos_buildflags.h"
 -#include "carbonyl/src/browser/bridge.h"
++#include "carbonyl/src/browser/bridge.h"
 +#include "carbonyl/src/browser/renderer.h"
 +#include "components/zoom/zoom_controller.h"
  #include "content/public/browser/browser_thread.h"
@@ -784,6 +790,7 @@ index a166a08f6ea15..091bde787d47c 100644
    HeadlessPrintManager::CreateForWebContents(web_contents_.get());
  #endif
 +  zoom::ZoomController::CreateForWebContents(web_contents_.get());
++  carbonyl::Bridge::SetWebContents(web_contents_.get());
    UpdatePrefsFromSystemSettings(web_contents_->GetMutableRendererPrefs());
    web_contents_->GetMutableRendererPrefs()->accept_languages =
        browser_context->options()->accept_language();

--- a/src/browser/bridge.h
+++ b/src/browser/bridge.h
@@ -3,6 +3,10 @@
 
 #include "carbonyl/src/browser/export.h"
 
+namespace content {
+class WebContents;
+}
+
 namespace carbonyl {
 
 class Renderer;
@@ -11,6 +15,10 @@ class CARBONYL_BRIDGE_EXPORT Bridge {
 public:
   static float GetDPI();
   static bool BitmapMode();
+  static float GetDeviceScaleFactor();
+  static void SetDeviceScaleFactor(float dsf);
+  static void SetDefaultZoom(float factor);
+  static void SetWebContents(content::WebContents* web_contents);
 
 private:
   friend class Renderer;
@@ -19,6 +27,11 @@ private:
   static void Configure(float dpi, bool bitmap_mode);
 };
 
+}
+
+extern "C" {
+CARBONYL_BRIDGE_EXPORT void carbonyl_set_device_scale_factor(float dsf);
+CARBONYL_BRIDGE_EXPORT void carbonyl_set_default_zoom(float factor);
 }
 
 #endif  // CARBONYL_SRC_BROWSER_BRIDGE_H_

--- a/src/browser/bridge.rs
+++ b/src/browser/bridge.rs
@@ -9,6 +9,10 @@ use libc::{c_char, c_float, c_int, c_uchar, c_uint, c_void, size_t};
 use crate::cli::{CommandLine, CommandLineProgram, EnvVar};
 use crate::gfx::{Cast, Color, Point, Rect, Size};
 use crate::output::{RenderThread, Window};
+
+extern "C" {
+    fn carbonyl_set_device_scale_factor(dsf: c_float);
+}
 use crate::ui::navigation::NavigationAction;
 use crate::{input, utils::log};
 
@@ -189,6 +193,8 @@ pub extern "C" fn carbonyl_renderer_resize(bridge: RendererPtr) {
     let cells = window.cells.clone();
     // Use the full terminal pixel geometry for SIXEL frames.
     let geometry = window.graphics_px;
+    // Keep Chromium informed of the effective device scale factor.
+    unsafe { carbonyl_set_device_scale_factor(window.dsf) };
 
     log::debug!("resizing renderer, terminal window: {:?}", window);
 

--- a/src/output/painter.rs
+++ b/src/output/painter.rs
@@ -81,7 +81,7 @@ impl Painter {
                 .unwrap_or(false);
 
             let dither = match env::var("CARBONYL_SIXEL_DITHER")
-                .unwrap_or_else(|_| "none".into())
+                .unwrap_or_else(|_| "fs".into())
                 .to_ascii_lowercase()
                 .as_str()
             {

--- a/src/output/render_thread.rs
+++ b/src/output/render_thread.rs
@@ -8,6 +8,10 @@ use crate::cli::CommandLine;
 
 use super::{FrameSync, Renderer};
 
+extern "C" {
+    fn carbonyl_set_default_zoom(factor: f32);
+}
+
 /// Control a rendering thread that lazily starts.
 /// This allows the `Bridge` struct to be used in places
 /// where we do not expected the rendering thread to start.
@@ -60,6 +64,9 @@ impl RenderThread {
         let cmd = CommandLine::parse();
         let mut sync = FrameSync::new(cmd.fps);
         let mut renderer = Renderer::new(cmd.sixel_only);
+        unsafe {
+            carbonyl_set_default_zoom(cmd.zoom.max(0.01));
+        }
         let mut needs_render = false;
 
         loop {


### PR DESCRIPTION
## Summary
- expose FFI hooks that keep Chromium's device scale factor in sync with the terminal and apply page zoom defaults
- update Chromium patches to scale the software backing store with the DSF and register the WebContents for zoom control
- default SIXEL rendering to FS dithering for sharper output while allowing overrides

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68db1d97dd80832ead16713aed04033d