### PR TITLE
Handle missing Chromium bridge symbols when building standalone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "chrono",
  "fast_image_resize",
  "libc",
+ "libloading",
  "sixel-bytes",
  "unicode-segmentation",
  "unicode-width",
@@ -452,6 +453,16 @@ checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
 dependencies = [
  "arbitrary",
  "cc",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -1169,6 +1180,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ unicode-segmentation = "1.10.0"
 chrono = "0.4.23"
 sixel-bytes = "0.2"
 fast_image_resize = { version = "5", features = ["rayon"] }
+libloading = "0.8"
 
 [lib]
 name = "carbonyl"

--- a/src/output/render_thread.rs
+++ b/src/output/render_thread.rs
@@ -4,13 +4,9 @@ use std::{
     time::Instant,
 };
 
-use crate::cli::CommandLine;
+use crate::{browser, cli::CommandLine};
 
 use super::{FrameSync, Renderer};
-
-extern "C" {
-    fn carbonyl_set_default_zoom(factor: f32);
-}
 
 /// Control a rendering thread that lazily starts.
 /// This allows the `Bridge` struct to be used in places
@@ -64,9 +60,7 @@ impl RenderThread {
         let cmd = CommandLine::parse();
         let mut sync = FrameSync::new(cmd.fps);
         let mut renderer = Renderer::new(cmd.sixel_only);
-        unsafe {
-            carbonyl_set_default_zoom(cmd.zoom.max(0.01));
-        }
+        browser::set_default_zoom(cmd.zoom.max(0.01));
         let mut needs_render = false;
 
         loop {


### PR DESCRIPTION
## Summary
- dynamically resolve Chromium bridge symbols so standalone cargo builds no longer fail when the native library is absent
- update render thread and resize logic to use safe Rust wrappers around the optional native calls
- add a libloading dependency to support runtime symbol lookups

## Testing
- cargo check


------
https://chatgpt.com/codex/tasks/task_e_68db217085cc832e901b78c42913cad1