### PR TITLE
Fix bridge component dependencies

### DIFF
--- a/src/browser/BUILD.gn
+++ b/src/browser/BUILD.gn
@@ -17,6 +17,11 @@ component("bridge") {
     "bridge.cc",
     "bridge.h",
   ]
+
+  deps = [
+    "//components/zoom",
+    "//content/public/browser:browser",
+  ]
 }
 
 component("viz") {


### PR DESCRIPTION
## Summary
- add the zoom and content dependencies to the carbonyl bridge GN target so Chromium headers resolve correctly during builds

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68db2a5e75d4832ea110dcd67751a956