### PR TITLE
Fix default zoom without zoom component dependency

### DIFF
--- a/src/browser/BUILD.gn
+++ b/src/browser/BUILD.gn
@@ -19,7 +19,6 @@ component("bridge") {
   ]
 
   deps = [
-    "//components/zoom",
     "//content/public/browser:browser",
   ]
 }


### PR DESCRIPTION
## Summary
- use HostZoomMap to apply the configured default zoom without depending on the zoom component
- remove the components/zoom dependency from the carbonyl bridge target to eliminate the GN cycle

## Testing
- cargo build *(fails: linking error from libsixel_sys_static when producing libcarbonyl.so)*

------
https://chatgpt.com/codex/tasks/task_e_68db2d485e48832e83ec62ed0409d93d