### PR TITLE
Break Skia bridge dependency cycle

### DIFF
--- a/chromium/patches/chromium/0014-Move-Skia-text-rendering-control-to-bridge.patch
+++ b/chromium/patches/chromium/0014-Move-Skia-text-rendering-control-to-bridge.patch
@@ -40,7 +40,7 @@ index b330273c16db3..297ffacf073fa 100644
  
  component("skia") {
 -  deps = []
-+  deps = [ "//carbonyl/src/browser:bridge" ]
++  deps = [ "//carbonyl/src/browser:bridge_state" ]
    sources = [
      # Chrome sources.
      "config/SkUserConfig.h",

--- a/chromium/patches/skia/0001-Disable-text-rendering.patch
+++ b/chromium/patches/skia/0001-Disable-text-rendering.patch
@@ -15,7 +15,7 @@ index b497d690f7..9631f47967 100644
  #include "src/image/SkImage_Base.h"
  #include "src/text/GlyphRun.h"
  
-+#include "carbonyl/src/browser/bridge.h"
++#include "carbonyl/src/browser/bridge_state.h"
 +
  struct Bounder {
      SkRect  fBounds;
@@ -26,7 +26,7 @@ index b497d690f7..9631f47967 100644
                                          const SkPaint& drawingPaint) {
 -    SkASSERT(!glyphRunList.hasRSXForm());
 -    LOOP_TILER( drawGlyphRunList(canvas, &fGlyphPainter, glyphRunList, drawingPaint), nullptr )
-+    if (carbonyl::Bridge::BitmapMode()) {
++    if (carbonyl::bridge::BitmapMode()) {
 +        SkASSERT(!glyphRunList.hasRSXForm());
 +        LOOP_TILER( drawGlyphRunList(canvas, &fGlyphPainter, glyphRunList, drawingPaint), nullptr )
 +    }

--- a/src/browser/BUILD.gn
+++ b/src/browser/BUILD.gn
@@ -19,8 +19,14 @@ component("bridge") {
   ]
 
   deps = [
+    ":bridge_state",
     "//content/public/browser:browser",
   ]
+}
+
+source_set("bridge_state") {
+  sources = [ "bridge_state.cc" ]
+  public = [ "bridge_state.h" ]
 }
 
 component("viz") {

--- a/src/browser/bridge.cc
+++ b/src/browser/bridge.cc
@@ -2,15 +2,13 @@
 
 #include <cmath>
 
+#include "carbonyl/src/browser/bridge_state.h"
 #include "content/public/browser/host_zoom_map.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
 
 namespace {
 
-float dpi_ = 0.0;
-bool bitmap_mode_ = false;
-float device_scale_factor_ = 1.0f;
 float default_zoom_factor_ = 1.0f;
 content::WebContents* web_contents_ = nullptr;
 
@@ -28,15 +26,15 @@ namespace carbonyl {
 void Bridge::Resize() {}
 
 float Bridge::GetDPI() {
-    return dpi_;
+    return bridge::GetDPI();
 }
 
 float Bridge::GetDeviceScaleFactor() {
-    return device_scale_factor_;
+    return bridge::GetDeviceScaleFactor();
 }
 
 bool Bridge::BitmapMode() {
-    return bitmap_mode_;
+    return bridge::BitmapMode();
 }
 
 void Bridge::SetDeviceScaleFactor(float dsf) {
@@ -46,8 +44,8 @@ void Bridge::SetDeviceScaleFactor(float dsf) {
         dsf = 3.0f;
     }
 
-    device_scale_factor_ = dsf;
-    dpi_ = dsf;
+    bridge::SetDeviceScaleFactor(dsf);
+    bridge::SetDPI(dsf);
 }
 
 void Bridge::SetDefaultZoom(float factor) {
@@ -88,7 +86,7 @@ void Bridge::SetWebContents(content::WebContents* web_contents) {
 }
 
 void Bridge::Configure(float dpi, bool bitmap_mode) {
-    bitmap_mode_ = bitmap_mode;
+    bridge::SetBitmapMode(bitmap_mode);
     Bridge::SetDeviceScaleFactor(dpi);
 }
 

--- a/src/browser/bridge_state.cc
+++ b/src/browser/bridge_state.cc
@@ -1,0 +1,38 @@
+#include "carbonyl/src/browser/bridge_state.h"
+
+namespace carbonyl {
+namespace bridge {
+namespace {
+
+bool bitmap_mode = false;
+float device_scale_factor = 1.0f;
+float dpi = 0.0f;
+
+}  // namespace
+
+bool BitmapMode() {
+  return bitmap_mode;
+}
+
+void SetBitmapMode(bool bitmap_mode_value) {
+  bitmap_mode = bitmap_mode_value;
+}
+
+float GetDeviceScaleFactor() {
+  return device_scale_factor;
+}
+
+void SetDeviceScaleFactor(float device_scale_factor_value) {
+  device_scale_factor = device_scale_factor_value;
+}
+
+float GetDPI() {
+  return dpi;
+}
+
+void SetDPI(float dpi_value) {
+  dpi = dpi_value;
+}
+
+}  // namespace bridge
+}  // namespace carbonyl

--- a/src/browser/bridge_state.h
+++ b/src/browser/bridge_state.h
@@ -1,0 +1,19 @@
+#ifndef CARBONYL_SRC_BROWSER_BRIDGE_STATE_H_
+#define CARBONYL_SRC_BROWSER_BRIDGE_STATE_H_
+
+namespace carbonyl {
+namespace bridge {
+
+bool BitmapMode();
+void SetBitmapMode(bool bitmap_mode);
+
+float GetDeviceScaleFactor();
+void SetDeviceScaleFactor(float device_scale_factor);
+
+float GetDPI();
+void SetDPI(float dpi);
+
+}  // namespace bridge
+}  // namespace carbonyl
+
+#endif  // CARBONYL_SRC_BROWSER_BRIDGE_STATE_H_


### PR DESCRIPTION
## Summary
- add a bridge_state target that exposes DPI and bitmap mode without pulling in content dependencies
- update bridge.cc to read and update the shared state helpers
- adjust Chromium and Skia patches so Skia links against the lightweight bridge_state target instead of the full bridge component

## Testing
- cargo build *(fails: linker cannot find glibc in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db2ffc5288832eb75734f3507043f1