### PR TITLE
Remove legacy rendering modes

### DIFF
--- a/src/browser/bridge.cc
+++ b/src/browser/bridge.cc
@@ -85,8 +85,8 @@ void Bridge::SetWebContents(content::WebContents* web_contents) {
     Bridge::SetDefaultZoom(default_zoom_factor_);
 }
 
-void Bridge::Configure(float dpi, bool bitmap_mode) {
-    bridge::SetBitmapMode(bitmap_mode);
+void Bridge::Configure(float dpi) {
+    bridge::SetBitmapMode(false);
     Bridge::SetDeviceScaleFactor(dpi);
 }
 

--- a/src/browser/bridge.h
+++ b/src/browser/bridge.h
@@ -24,7 +24,7 @@ private:
   friend class Renderer;
 
   static void Resize();
-  static void Configure(float dpi, bool bitmap_mode);
+  static void Configure(float dpi);
 };
 
 }

--- a/src/browser/bridge.rs
+++ b/src/browser/bridge.rs
@@ -192,12 +192,6 @@ fn main() -> io::Result<Option<i32>> {
     let mut terminal = input::Terminal::setup();
     let mut command = Command::new(env::current_exe()?);
 
-    if !cmd.bitmap {
-        command
-            .arg("--disable-threaded-scrolling")
-            .arg("--disable-threaded-animation");
-    }
-
     let output = command
         .args(cmd.args)
         .env(EnvVar::ShellMode, "1")
@@ -222,11 +216,6 @@ pub extern "C" fn carbonyl_bridge_main() {
     if let Some(code) = main().unwrap() {
         std::process::exit(code)
     }
-}
-
-#[no_mangle]
-pub extern "C" fn carbonyl_bridge_bitmap_mode() -> bool {
-    CommandLine::parse().bitmap
 }
 
 #[no_mangle]

--- a/src/browser/bridge_state.cc
+++ b/src/browser/bridge_state.cc
@@ -4,18 +4,17 @@ namespace carbonyl {
 namespace bridge {
 namespace {
 
-bool bitmap_mode = false;
 float device_scale_factor = 1.0f;
 float dpi = 0.0f;
 
 }  // namespace
 
 bool BitmapMode() {
-  return bitmap_mode;
+  return false;
 }
 
 void SetBitmapMode(bool bitmap_mode_value) {
-  bitmap_mode = bitmap_mode_value;
+  (void)bitmap_mode_value;
 }
 
 float GetDeviceScaleFactor() {

--- a/src/browser/renderer.cc
+++ b/src/browser/renderer.cc
@@ -35,7 +35,6 @@ struct carbonyl_renderer_text {
 };
 
 void carbonyl_bridge_main();
-bool carbonyl_bridge_bitmap_mode();
 float carbonyl_bridge_get_dpi();
 
 struct carbonyl_renderer* carbonyl_renderer_create();
@@ -73,10 +72,7 @@ Renderer::Renderer(struct carbonyl_renderer* ptr): ptr_(ptr) {}
 void Renderer::Main() {
     carbonyl_bridge_main();
 
-    Bridge::Configure(
-        carbonyl_bridge_get_dpi(),
-        carbonyl_bridge_bitmap_mode()
-    );
+    Bridge::Configure(carbonyl_bridge_get_dpi());
 }
 
 Renderer* Renderer::GetCurrent() {

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -8,16 +8,12 @@ pub struct CommandLine {
     pub fps: f32,
     pub zoom: f32,
     pub debug: bool,
-    pub bitmap: bool,
-    pub sixel_only: bool,
     pub program: CommandLineProgram,
     pub shell_mode: bool,
 }
 
 pub enum EnvVar {
     Debug,
-    Bitmap,
-    SixelOnly,
     ShellMode,
 }
 
@@ -25,8 +21,6 @@ impl EnvVar {
     pub fn as_str(&self) -> &'static str {
         match self {
             EnvVar::Debug => "CARBONYL_ENV_DEBUG",
-            EnvVar::Bitmap => "CARBONYL_ENV_BITMAP",
-            EnvVar::SixelOnly => "CARBONYL_ENV_SIXEL_ONLY",
             EnvVar::ShellMode => "CARBONYL_ENV_SHELL_MODE",
         }
     }
@@ -43,8 +37,6 @@ impl CommandLine {
         let mut fps = 60.0;
         let mut zoom = 1.0;
         let mut debug = false;
-        let mut bitmap = false;
-        let mut sixel_only = true;
         let mut shell_mode = false;
         let mut program = CommandLineProgram::Main;
         let args = env::args().skip(1).collect::<Vec<String>>();
@@ -80,14 +72,6 @@ impl CommandLine {
                 "-f" | "--fps" => set_f32!(fps = fps),
                 "-z" | "--zoom" => set_f32!(zoom = zoom / 100.0),
                 "-d" | "--debug" => set!(debug, Debug),
-                "-b" | "--bitmap" => set!(bitmap, Bitmap),
-                "--sixel-only" => set!(sixel_only, SixelOnly),
-                "--legacy-text" => {
-                    sixel_only = false;
-
-                    env::set_var(EnvVar::SixelOnly, "0");
-                }
-
                 "-h" | "--help" => program = CommandLineProgram::Help,
                 "-v" | "--version" => program = CommandLineProgram::Version,
                 _ => (),
@@ -98,18 +82,6 @@ impl CommandLine {
             debug = true;
         }
 
-        if env::var(EnvVar::Bitmap).is_ok() {
-            bitmap = true;
-        }
-
-        if let Ok(value) = env::var(EnvVar::SixelOnly) {
-            let normalized = value.trim().to_ascii_lowercase();
-
-            sixel_only = !matches!(normalized.as_str(), "0" | "false" | "off" | "no");
-        }
-
-        env::set_var(EnvVar::SixelOnly, if sixel_only { "1" } else { "0" });
-
         if env::var(EnvVar::ShellMode).is_ok() {
             shell_mode = true;
         }
@@ -119,8 +91,6 @@ impl CommandLine {
             fps,
             zoom,
             debug,
-            bitmap,
-            sixel_only,
             program,
             shell_mode,
         }

--- a/src/cli/usage.txt
+++ b/src/cli/usage.txt
@@ -9,8 +9,6 @@ Usage: carbonyl [options] [url]
 Options:
     -f, --fps=<fps>            set the maximum number of frames per second (default: 60)
     -z, --zoom=<zoom>          set the zoom level in percent (default: 100)
-        --legacy-text          re-enable the legacy ANSI text renderer
-    -b, --bitmap               render text as bitmaps
     -d, --debug                enable debug logs
     -h, --help                 display this help message
     -v, --version              output the version number

--- a/src/output/painter.rs
+++ b/src/output/painter.rs
@@ -23,7 +23,6 @@ pub struct Painter {
     background_code: Option<u8>,
     foreground_code: Option<u8>,
     sixel: Option<SixelState>,
-    sixel_only: bool,
 }
 
 struct SixelState {
@@ -49,7 +48,6 @@ impl Painter {
                 "truecolor" | "24bit" => true,
                 _ => false,
             },
-            sixel_only: false,
         }
     }
 
@@ -59,10 +57,6 @@ impl Painter {
 
     pub fn set_true_color(&mut self, true_color: bool) {
         self.true_color = true_color
-    }
-
-    pub fn set_sixel_only(&mut self, sixel_only: bool) {
-        self.sixel_only = sixel_only;
     }
 
     pub fn enable_sixel(&mut self, geometry: Size<u32>) {
@@ -218,14 +212,10 @@ impl Painter {
             cursor,
             quadrant,
             ref grapheme,
-            image,
+            image: _,
         } = cell;
 
-        if self.sixel_only && self.sixel_enabled() {
-            return Ok(());
-        }
-
-        if self.sixel_enabled() && grapheme.is_none() && image {
+        if self.sixel_enabled() {
             return Ok(());
         }
 

--- a/src/output/render_thread.rs
+++ b/src/output/render_thread.rs
@@ -59,7 +59,7 @@ impl RenderThread {
     fn boot(rx: Receiver<Message>) {
         let cmd = CommandLine::parse();
         let mut sync = FrameSync::new(cmd.fps);
-        let mut renderer = Renderer::new(cmd.sixel_only);
+        let mut renderer = Renderer::new();
         browser::set_default_zoom(cmd.zoom.max(0.01));
         let mut needs_render = false;
 

--- a/src/output/renderer.rs
+++ b/src/output/renderer.rs
@@ -23,9 +23,8 @@ pub struct Renderer {
 }
 
 impl Renderer {
-    pub fn new(sixel_only: bool) -> Renderer {
-        let mut painter = Painter::new();
-        painter.set_sixel_only(sixel_only);
+    pub fn new() -> Renderer {
+        let painter = Painter::new();
 
         Renderer {
             nav: Navigation::new(),


### PR DESCRIPTION
## Summary
- remove deprecated bitmap/text CLI flags so the browser always runs in Sixel mode
- drop runtime bitmap toggles in the bridge and force Chromium text rendering to stay disabled
- simplify the renderer pipeline by eliminating the Sixel-only flag and always skipping ANSI fallbacks when Sixel output is active

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68db33902784832ea775f7226547697b